### PR TITLE
Prune redundant code

### DIFF
--- a/lib/wabbit/gen_stage.ex
+++ b/lib/wabbit/gen_stage.ex
@@ -108,18 +108,6 @@ defmodule Wabbit.GenStage do
       @behaviour Wabbit.GenStage
 
       @doc false
-      def handle_channel_opened(channel, %{type: :consumer} = state) do
-        {:ok, state}
-      end
-
-      @doc false
-      def handle_channel_opened(channel, %{type: :producer} = state) do
-        {:ok, %{queue: queue}} =
-          Wabbit.Queue.declare(channel, "", auto_delete: true)
-        {:ok, queue, state}
-      end
-
-      @doc false
       def handle_encode(message, state) do
         {:ok, inspect(message), state}
       end


### PR DESCRIPTION
Since the **handle_channel_opened** callback isn't optional and in line [383](https://github.com/pma/wabbit/blob/master/lib/wabbit/gen_stage.ex#L383) the outer state is passed in instead of the inner state, these lines are redundant and confusing.